### PR TITLE
Fix build on windows platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ categories = ["api-bindings", "multimedia::images"]
 
 [build-dependencies]
 bindgen = "0.52"
+[target.'cfg(windows)'.build-dependencies]
+vcpkg = "0.2.8"
+
+

--- a/README.md
+++ b/README.md
@@ -20,3 +20,33 @@ On Termux 2019 (Android, Android on Chromebooks) the additional dependencies can
 ```bash
 pkg install libclang leptonica-dev
 ```
+
+### Building on Windows
+    
+On Windows, this library uses Microsoft's [vcpkg](https://github.com/microsoft/vcpkg) to provide leptonica.
+    
+Please install [vcpkg](https://github.com/microsoft/vcpkg) and **set up user wide integration** or [vcpkg crate](https://crates.io/crates/vcpkg) won't be able to find a library.
+By default vcpkg installs 32 bit libraries. If you need 64 bit libraries then set following environment variable
+
+```cmd
+SET VCPKG_DEFAULT_TRIPLET=x64-windows
+```
+To install leptonica
+
+```cmd
+REM from the vcpkg directory
+.\vcpkg install leptonica
+```
+
+vcpkg allows building either dynamically or statically linked application
+
+if you prefer dynamic linking
+
+```cmd
+SET VCPKGRS_DYNAMIC=true
+```
+
+for statically linked libraries
+
+```cmd
+SET RUSTFLAGS=-Ctarget-feature=+crt-static

--- a/build.rs
+++ b/build.rs
@@ -2,12 +2,37 @@ extern crate bindgen;
 
 use std::env;
 use std::path::PathBuf;
+#[cfg(windows)]
+use vcpkg;
+
+#[cfg(windows)]
+fn find_leptonica_system_lib() -> Option<String> {
+    let lib = vcpkg::Config::new().find_package("leptonica").unwrap();
+
+    let include = lib
+        .include_paths
+        .iter()
+        .map(|x| x.to_string_lossy())
+        .collect::<String>();
+    Some(include)
+}
+
+#[cfg(not(windows))]
+fn find_leptonica_system_lib() -> Option<String> {
+    println!("cargo:rustc-link-lib=lept");
+    None
+}
 
 fn main() {
-    println!("cargo:rustc-link-lib=lept");
+    let clang_extra_include = find_leptonica_system_lib();
 
-    let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+    let mut bindings = bindgen::Builder::default().header("wrapper.h");
+
+    if let Some(include_path) = clang_extra_include {
+        bindings = bindings.clang_arg(format!("-I{}", include_path));
+    }
+
+    let bindings = bindings
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .generate()
         .expect("Unable to generate bindings");


### PR DESCRIPTION
This library on Windows is destrebuted using VCPKG
(https://github.com/microsoft/vcpkg). This commit uses crate 'vcpgk' to
locate installed libraries and automatically provide library name for
cargo.

bindgen needs extra include directory to locate library headers. It
is implemented using clang_arg() method.

VCPKG is also available of Linux and MacOS but on most users use
standard package manages so vcpkg is called on Windows only