### PR TITLE
Bump bindgen to 54

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica-sys"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Chris Couzens <ccouzens@gmail.com>"]
 edition = "2018"
 links = "lept"
@@ -12,7 +12,7 @@ keywords = ["leptonica"]
 categories = ["api-bindings", "multimedia::images"]
 
 [build-dependencies]
-bindgen = "0.52"
+bindgen = "0.54"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
 


### PR DESCRIPTION
Hey there, leptonica depending on an older version of bindgen is causing me some dependency conflicts since it's pulling in an older version of clang.

Do you mind releasing 0.3.2 with this bindgen version bump?