### PR TITLE
Support build on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,9 @@ categories = ["api-bindings", "multimedia::images"]
 
 [build-dependencies]
 bindgen = "0.56"
+
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
+
+[target.'cfg(target_os="macos")'.build-dependencies]
+pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -4,6 +4,10 @@ use std::env;
 use std::path::PathBuf;
 #[cfg(windows)]
 use vcpkg;
+#[cfg(target_os="macos")]
+use pkg_config;
+
+// const MINIMUM_LEPT_VERSION: &str = "1.80.0";
 
 #[cfg(windows)]
 fn find_leptonica_system_lib() -> Option<String> {
@@ -17,7 +21,25 @@ fn find_leptonica_system_lib() -> Option<String> {
     Some(include)
 }
 
-#[cfg(not(windows))]
+// On macOS, we sometimes need additional search paths, which we get using pkg-config
+#[cfg(target_os="macos")]
+fn find_leptonica_system_lib() -> Option<String> {
+    let pk = pkg_config::Config::new()
+        // .atleast_version(MINIMUM_LEPT_VERSION)
+        .probe("lept")
+        .unwrap();
+    // Tell cargo to tell rustc to link the system proj shared library.
+    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
+    println!("cargo:rustc-link-lib=lept");
+
+    let mut include_path = pk.include_paths[0].clone();
+    // The include file used in this project has "leptonica" as part of 
+    // the header file already
+    include_path.pop();
+    Some(include_path.to_string_lossy().to_string())
+}
+
+#[cfg(all(not(windows), not(target_os="macos")))]
 fn find_leptonica_system_lib() -> Option<String> {
     println!("cargo:rustc-link-lib=lept");
     None


### PR DESCRIPTION
When trying to build on Mac, the following error shows:

`
Compiling leptonica-sys v0.3.4 
error: failed to run custom build command for leptonica-sys v0.3.4

Caused by:
  process didn't exit successfully
  
  --- stdout
  cargo:rustc-link-lib=lept

  --- stderr
  wrapper.h:1:10: fatal error: 'allheaders.h' file not found
  wrapper.h:1:10: fatal error: 'allheaders.h' file not found, err: true
  thread 'main' panicked at 'Unable to generate bindings: ()', build.rs:58:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
`

The error is due to the linker not finding the library path and later not been able to include the headers properly.

The build.rs needs adaption to Mac, using pkg-config crate (similar to vcpkg on Windows)

- tested after 'brew install leptonica'
- tested on Mac M1
- **not** tested on Linux or Windows