### PR TITLE
Add supporting custom install prefix for native on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,5 @@ bindgen = "0.56"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.8"
 
-[target.'cfg(target_os="macos")'.build-dependencies]
-pkg-config = "0.3.19"
-
-[target.'cfg(target_os="linux")'.build-dependencies]
-pkg-config = "0.3.19"
+[target.'cfg(any(target_os="macos", target_os="linux"))'.build-dependencies]
+pkg-config = "0.3.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ bindgen = "0.56"
 vcpkg = "0.2.8"
 
 [target.'cfg(any(target_os="macos", target_os="linux"))'.build-dependencies]
-pkg-config = "0.3.23"
+pkg-config = "0.3.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ vcpkg = "0.2.8"
 
 [target.'cfg(target_os="macos")'.build-dependencies]
 pkg-config = "0.3.19"
+
+[target.'cfg(target_os="linux")'.build-dependencies]
+pkg-config = "0.3.19"

--- a/build.rs
+++ b/build.rs
@@ -21,25 +21,11 @@ fn find_leptonica_system_lib() -> Option<String> {
     Some(include)
 }
 
-// On macOS, we sometimes need additional search paths, which we get using pkg-config
-#[cfg(target_os = "macos")]
-fn find_leptonica_system_lib() -> Option<String> {
-    let pk = pkg_config::Config::new()
-        // .atleast_version(MINIMUM_LEPT_VERSION)
-        .probe("lept")
-        .unwrap();
-    // Tell cargo to tell rustc to link the system proj shared library.
-    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
-    println!("cargo:rustc-link-lib=lept");
-
-    let mut include_path = pk.include_paths[0].clone();
-    // The include file used in this project has "leptonica" as part of
-    // the header file already
-    include_path.pop();
-    Some(include_path.to_string_lossy().to_string())
-}
-
-#[cfg(target_os = "linux")]
+// we sometimes need additional search paths, which we get using pkg-config
+// we can use leptonica installed anywhere on Linux.
+// if you change install path(--prefix) to `configure` script.
+// set `export PKG_CONFIG_PATH=/path-to-lib/pkgconfig` before.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn find_leptonica_system_lib() -> Option<String> {
     let pk = pkg_config::Config::new().probe("lept").unwrap();
     // Tell cargo to tell rustc to link the system proj shared library.

--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,23 @@ fn find_leptonica_system_lib() -> Option<String> {
     Some(include_path.to_string_lossy().to_string())
 }
 
-#[cfg(all(not(windows), not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
+fn find_leptonica_system_lib() -> Option<String> {
+    let pk = pkg_config::Config::new()
+        .probe("lept")
+        .unwrap();
+    // Tell cargo to tell rustc to link the system proj shared library.
+    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
+    println!("cargo:rustc-link-lib=lept");
+
+    let mut include_path = pk.include_paths[0].clone();
+    // The include file used in this project has "leptonica" as part of
+    // the header file already
+    include_path.pop();
+    Some(include_path.to_string_lossy().to_string())
+}
+
+#[cfg(all(not(windows), not(target_os = "macos"), not(target_os = "linux")))]
 fn find_leptonica_system_lib() -> Option<String> {
     println!("cargo:rustc-link-lib=lept");
     None

--- a/build.rs
+++ b/build.rs
@@ -41,9 +41,7 @@ fn find_leptonica_system_lib() -> Option<String> {
 
 #[cfg(target_os = "linux")]
 fn find_leptonica_system_lib() -> Option<String> {
-    let pk = pkg_config::Config::new()
-        .probe("lept")
-        .unwrap();
+    let pk = pkg_config::Config::new().probe("lept").unwrap();
     // Tell cargo to tell rustc to link the system proj shared library.
     println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
     println!("cargo:rustc-link-lib=lept");


### PR DESCRIPTION
Hello 
I tried to build this crate with builded from source leptonica

I used script like this

```
wget http://www.leptonica.org/source/leptonica-1.79.0.tar.gz
tar -zxvf leptonica-1.79.0.tar.gz
cd leptonica-1.79.0
./configure --prefix=${HOME}/local/leptonica-1.79.0
make
make install
```
After that tried to build the crate.
It failed

```
--- stderr
  wrapper.h:1:10: fatal error: 'leptonica/allheaders.h' file not found
  wrapper.h:1:10: fatal error: 'leptonica/allheaders.h' file not found, err: true
  thread 'main' panicked at 'Unable to generate bindings: ()', build.rs:60:10
```
I added `pkg_config` for Linux
And setted before running `cargo build`

```shell
export PKG_CONFIG_PATH=${HOME}/local/leptonica-1.80.0/lib/pkgconfig
```

It allow to change install prefix for native leptonica.
If  `PKG_CONFIG_PATH` not set It works with system lib.
I checked on Ubuntu 20.04 and lib `libleptonica-dev`

