### PR TITLE
Add support for manually compiled windows env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ for statically linked libraries
 ```cmd
 SET RUSTFLAGS=-Ctarget-feature=+crt-static
 ```
+
+If you prefer to compile tesseract yourself (Because, for example, you could not get vcpkg to build using clang-cl.exe), you can set these environment variables: `LEPTONICA_INCLUDE_PATH`, `LEPTONICA_LINK_PATHS` and `LEPTONICA_LINK_LIBS`.
+
+For example:
+
+```
+set LEPTONICA_INCLUDE_PATH=D:\leptonica\build\include
+set LEPTONICA_LINK_PATHS=D:\leptonica\build\lib
+set LEPTONICA_LINK_LIBS=leptonica-1.83.0
+```


### PR DESCRIPTION
Hi, this PR should add support for manually setting env vars to point to a manually compiled tesseract on windows (Similar to what the [opencv](https://github.com/twistedfall/opencv-rust) crate allows).

In case my usecase is relevant, I'm trying to compile on windows with the msvc toolchain using cross language LTO. To do so, I need to use clang instead of msvc's cl.exe (Since the LTO uses LLVM bitcode and MSVC does not know how to generate that, only clang does), and I'm specifically using clang-cl.exe . VCPKG [does not support a clang-cl triplet](https://github.com/microsoft/vcpkg/issues/2087), not even in it's community triplets. I tried using [this custom triplet someone uploaded on github](https://github.com/Neumann-A/my-vcpkg-triplets/blob/master/x64-windows-llvm.cmake) but have not gotten it to work so far.

I'm opening an equivalent PR on tesseract-sys https://github.com/ccouzens/tesseract-sys/pull/11