### PR TITLE
Support leptonica:1.83.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --lib
     - name: Check formatting
       run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptonica-sys"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Chris Couzens <ccouzens@gmail.com>"]
 edition = "2018"
 links = "lept"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,14 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 #[cfg(test)]
 mod tests {
-    use super::{pixFreeData, pixRead};
-    use std::ffi::CStr;
+    use super::{pixFreeData, pixGetHeight, pixGetWidth, pixRead};
 
     #[test]
     fn image_size() {
         unsafe {
-            let image =
-                pixRead(CStr::from_bytes_with_nul_unchecked(b"../test image.png\0").as_ptr());
-            assert_eq!((*image).w, 1000);
-            assert_eq!((*image).h, 500);
+            let image = pixRead(b"../test image.png\0".as_ptr().cast());
+            assert_eq!(pixGetWidth(image), 1000);
+            assert_eq!(pixGetHeight(image), 500);
             pixFreeData(image);
         }
     }


### PR DESCRIPTION
I've had to disable doc tests because some of the syntax in the autogenerated comments confuses it.

It looks like access to the PIX struct is now private, so we need to use getters.

I started looking at this because of this issue in leptonica-plumbing https://github.com/ccouzens/leptonica-plumbing/issues/5

---

To test using my dev version of leptonica I need to use this command

```bash
LD_LIBRARY_PATH=../../DanBloomberg/leptonica/local/lib PKG_CONFIG_PATH=../../DanBloomberg/leptonica/local/lib/pkgconfig cargo test --lib
```

My checkout of leptonica was built with

```bash
sudo dnf builddep leptonica-devel
./autogen.sh
./configure --prefix
 /configure "--prefix=$(pwd)/local"
make
make install
```