### PR TITLE
Use leptonica library name provided by pkg-config

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,7 +57,7 @@ fn find_leptonica_system_lib() -> Option<String> {
     let pk = pkg_config::Config::new().probe("lept").unwrap();
     // Tell cargo to tell rustc to link the system proj shared library.
     println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
-    println!("cargo:rustc-link-lib=lept");
+    println!("cargo:rustc-link-lib={}", pk.libs[0]);
 
     let mut include_path = pk.include_paths[0].clone();
     // The include file used in this project has "leptonica" as part of


### PR DESCRIPTION
The latest release of leptonica-sys fails to link on Archlinux due to the fact that the so-name differs.
On Arch:
```
$ pkg-config --libs lept
-lleptonica
```
On Ubuntu:
```
$ pkg-config --libs lept
-llept
```

However, the `build.rs` currently always uses `lept`, leading to linker errors on Arch. This PR changes that and uses the library name provided by `pkg-config` instead.

I tested the changes in both the `archlinux:latest` and `ubuntu:latest` docker containers.