### PR TITLE
Use `pkg_config` to query include and library directories on FreeBSD as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ bindgen = "0.64.0"
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.15"
 
-[target.'cfg(any(target_os="macos", target_os="linux"))'.build-dependencies]
+[target.'cfg(any(target_os="macos", target_os="linux", target_os="freebsd"))'.build-dependencies]
 pkg-config = "0.3.25"

--- a/build.rs
+++ b/build.rs
@@ -50,7 +50,7 @@ fn find_leptonica_system_lib() -> Option<String> {
 // we can use leptonica installed anywhere on Linux.
 // if you change install path(--prefix) to `configure` script.
 // set `export PKG_CONFIG_PATH=/path-to-lib/pkgconfig` before.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
 fn find_leptonica_system_lib() -> Option<String> {
     let pk = pkg_config::Config::new().probe("lept").unwrap();
     // Tell cargo to tell rustc to link the system proj shared library.
@@ -64,7 +64,12 @@ fn find_leptonica_system_lib() -> Option<String> {
     Some(include_path.to_str().unwrap().into())
 }
 
-#[cfg(all(not(windows), not(target_os = "macos"), not(target_os = "linux")))]
+#[cfg(all(
+    not(windows),
+    not(target_os = "macos"),
+    not(target_os = "linux"),
+    not(target_os = "freebsd")
+))]
 fn find_leptonica_system_lib() -> Option<String> {
     println!("cargo:rustc-link-lib=lept");
     None


### PR DESCRIPTION
This makes it possible to build the crate on `FreeBSD`.