### PR TITLE
Force clang into C++ mode on windows to fix leptonica header issues

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -74,6 +74,11 @@ fn main() {
     let clang_extra_include = find_leptonica_system_lib();
 
     let mut bindings = bindgen::Builder::default().header("wrapper.h");
+    
+    #[cfg(windows)]
+    {
+        bindings = bindings.clang_args(["-x", "c++"]);
+    }
 
     if let Some(include_path) = clang_extra_include {
         bindings = bindings.clang_arg(format!("-I{}", include_path));


### PR DESCRIPTION
Fixes #16. 

It seems that clang is running in C mode on windows, setting __STDC_VERSION__ to C11 or newer. Leptonica's headers include the standard atomics library if this is set, but MSVC does not support the standard atomics library in c mode, which causes the bindings generation to fail. 

```
  C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.32.31326\include\stdatomic.h:15:2: error: <stdatomic.h> is not yet supported when compiling as C, but this is planned for a future release.
  C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.32.31326\include\yvals_core.h:23:2: error: STL1003: Unexpected compiler, expected C++ compiler.
  C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.32.31326\include\yvals.h:341:1: error: unknown type name 'namespace'
  C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.32.31326\include\yvals.h:341:1: error: expected ';' after top level declarator
```

_leptonica/environ.h_
```
#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
#include <stdatomic.h>
typedef atomic_int l_atomic;
#else
typedef int l_atomic;
#endif
```

Forcing clang into C++ mode fixes this - presumably __STDC_VERSION__ is undefined in C++ mode, so the typedef is used instead.