### PR TITLE
Remove c++ clang argument from bindgen, because it was preventing export fn's from being generated in bindings.rs output file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,11 +80,6 @@ fn main() {
 
     let mut bindings = bindgen::Builder::default().header("wrapper.h");
 
-    #[cfg(windows)]
-    {
-        bindings = bindings.clang_args(["-x", "c++"]);
-    }
-
     if let Some(include_path) = clang_extra_include {
         bindings = bindings.clang_arg(format!("-I{}", include_path));
     }


### PR DESCRIPTION
fixes issue:
https://github.com/ccouzens/leptonica-plumbing/issues/10