### PR TITLE
 Remove dependency on system packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "leptonica"]
 	path = leptonica
-	url = git@github.com:DanBloomberg/leptonica.git
+	url = https://github.com/DanBloomberg/leptonica.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "leptonica"]
+	path = leptonica
+	url = git@github.com:DanBloomberg/leptonica.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings", "multimedia::images"]
 
 [build-dependencies]
 bindgen = "0.64.0"
+cmake = "0.1"
 
 [target.'cfg(windows)'.build-dependencies]
 vcpkg = "0.2.15"

--- a/build.rs
+++ b/build.rs
@@ -37,12 +37,26 @@ fn main() {
 
     bindings = bindings
         .blocklist_type("max_align_t")
+        // u128
         .blocklist_function("qecvt_r")
         .blocklist_function("qfcvt_r")
         .blocklist_function("qecvt")
         .blocklist_function("qfcvt")
         .blocklist_function("qgcvt")
-        .blocklist_function("strtold");
+        .blocklist_function("strtold")
+        // [u64; 4usize]
+        .blocklist_function("vasprintf")
+        .blocklist_function("vdprintf")
+        .blocklist_function("vfprintf")
+        .blocklist_function("vfscanf")
+        .blocklist_function("vfscanf1")
+        .blocklist_function("vprintf")
+        .blocklist_function("vscanf")
+        .blocklist_function("vscanf1")
+        .blocklist_function("vsnprintf")
+        .blocklist_function("vsprintf")
+        .blocklist_function("vsscanf")
+        .blocklist_function("vsscanf1");
 
     let bindings = bindings
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/build.rs
+++ b/build.rs
@@ -3,14 +3,13 @@ extern crate cmake;
 
 use std::env;
 use std::path::PathBuf;
-#[cfg(windows)]
-use vcpkg;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let target = env::var("TARGET").unwrap();
 
     let _dst = cmake::Config::new("leptonica")
+        .define("ANDROID_BUILD", "ON")
         .define("BUILD_PROG", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("ENABLE_ZLIB", "OFF")
@@ -36,7 +35,14 @@ fn main() {
         .header("wrapper.h")
         .clang_arg(format!("-I{}", include_path.display()));
 
-    bindings = bindings.blocklist_type("max_align_t");
+    bindings = bindings
+        .blocklist_type("max_align_t")
+        .blocklist_function("qecvt_r")
+        .blocklist_function("qfcvt_r")
+        .blocklist_function("qecvt")
+        .blocklist_function("qfcvt")
+        .blocklist_function("qgcvt")
+        .blocklist_function("strtold");
 
     let bindings = bindings
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/build.rs
+++ b/build.rs
@@ -44,6 +44,7 @@ fn main() {
         .blocklist_function("qfcvt")
         .blocklist_function("qgcvt")
         .blocklist_function("strtold")
+        .blocklist_function("strtold_l")
         // [u64; 4usize]
         .blocklist_function("vasprintf")
         .blocklist_function("vdprintf")

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,22 @@ fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
     let target = env::var("TARGET").unwrap();
 
-    let _dst = cmake::Config::new("leptonica")
+    let mut config = cmake::Config::new("leptonica");
+    for var in [
+        "CMAKE_TOOLCHAIN_FILE",
+        "CMAKE_SYSTEM_NAME",
+        "CMAKE_SYSTEM_PROCESSOR",
+        "CMAKE_C_COMPILER",
+        "CMAKE_CXX_COMPILER",
+        "ANDROID_ABI",
+        "ANDROID_PLATFORM",
+    ] {
+        println!("cargo:rerun-if-env-changed={var}");
+        if let Ok(value) = env::var(var) {
+            config.define(var, &value);
+        }
+    }
+    let _dst = config
         .define("ANDROID_BUILD", "ON")
         .define("BUILD_PROG", "OFF")
         .define("BUILD_SHARED_LIBS", "OFF")
@@ -20,7 +35,10 @@ fn main() {
         .define("ENABLE_WEBP", "OFF")
         .define("ENABLE_OPENJPEG", "OFF")
         .define("CMAKE_INSTALL_PREFIX", &out_dir)
-        .define("CMAKE_C_FLAGS", "-DMINIMUM_SEVERITY=6")
+        .define(
+            "CMAKE_C_FLAGS",
+            "-DMINIMUM_SEVERITY=6 -ffunction-sections -fdata-sections -fPIC",
+        )
         .out_dir(&format!("{}/leptonica-build-{}", out_dir, target))
         .always_configure(true)
         .build();

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ fn main() {
         .define("ENABLE_WEBP", "OFF")
         .define("ENABLE_OPENJPEG", "OFF")
         .define("CMAKE_INSTALL_PREFIX", &out_dir)
+        .define("CMAKE_C_FLAGS", "-DMINIMUM_SEVERITY=6")
         .out_dir(&format!("{}/leptonica-build-{}", out_dir, target))
         .always_configure(true)
         .build();

--- a/build.rs
+++ b/build.rs
@@ -1,88 +1,39 @@
 extern crate bindgen;
+extern crate cmake;
 
 use std::env;
 use std::path::PathBuf;
 #[cfg(windows)]
 use vcpkg;
 
-// const MINIMUM_LEPT_VERSION: &str = "1.80.0";
-
-#[cfg(windows)]
-fn find_leptonica_system_lib() -> Option<String> {
-    println!("cargo:rerun-if-env-changed=LEPTONICA_INCLUDE_PATH");
-    println!("cargo:rerun-if-env-changed=LEPTONICA_LINK_PATHS");
-    println!("cargo:rerun-if-env-changed=LEPTONICA_LINK_LIBS");
-
-    let vcpkg = || {
-        let lib = vcpkg::Config::new().find_package("leptonica").unwrap();
-
-        let include = lib
-            .include_paths
-            .iter()
-            .map(|x| x.to_string_lossy())
-            .collect::<String>();
-        Some(include)
-    };
-
-    let include_path = env::var("LEPTONICA_INCLUDE_PATH").ok();
-    let link_paths = env::var("LEPTONICA_LINK_PATHS").ok();
-    let link_paths = link_paths.as_deref().map(|x| x.split(','));
-    let link_libs = env::var("LEPTONICA_LINK_LIBS").ok();
-    let link_libs = link_libs.as_deref().map(|x| x.split(','));
-    if let (Some(include_path), Some(link_paths), Some(link_libs)) =
-        (include_path, link_paths, link_libs)
-    {
-        for link_path in link_paths {
-            println!("cargo:rustc-link-search={}", link_path)
-        }
-
-        for link_lib in link_libs {
-            println!("cargo:rustc-link-lib={}", link_lib)
-        }
-
-        Some(include_path)
-    } else {
-        vcpkg()
-    }
-}
-
-// we sometimes need additional search paths, which we get using pkg-config
-// we can use leptonica installed anywhere on Linux.
-// if you change install path(--prefix) to `configure` script.
-// set `export PKG_CONFIG_PATH=/path-to-lib/pkgconfig` before.
-#[cfg(any(target_os = "macos", target_os = "linux", target_os = "freebsd"))]
-fn find_leptonica_system_lib() -> Option<String> {
-    let pk = pkg_config::Config::new().probe("lept").unwrap();
-    // Tell cargo to tell rustc to link the system proj shared library.
-    println!("cargo:rustc-link-search=native={:?}", pk.link_paths[0]);
-    println!("cargo:rustc-link-lib={}", pk.libs[0]);
-
-    let mut include_path = pk.include_paths[0].clone();
-    if include_path.ends_with("leptonica") {
-        include_path.pop();
-    }
-    Some(include_path.to_str().unwrap().into())
-}
-
-#[cfg(all(
-    not(windows),
-    not(target_os = "macos"),
-    not(target_os = "linux"),
-    not(target_os = "freebsd")
-))]
-fn find_leptonica_system_lib() -> Option<String> {
-    println!("cargo:rustc-link-lib=lept");
-    None
-}
-
 fn main() {
-    let clang_extra_include = find_leptonica_system_lib();
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let target = env::var("TARGET").unwrap();
 
-    let mut bindings = bindgen::Builder::default().header("wrapper.h");
+    let _dst = cmake::Config::new("leptonica")
+        .define("BUILD_PROG", "OFF")
+        .define("BUILD_SHARED_LIBS", "OFF")
+        .define("ENABLE_ZLIB", "OFF")
+        .define("ENABLE_PNG", "OFF")
+        .define("ENABLE_GIF", "OFF")
+        .define("ENABLE_JPEG", "OFF")
+        .define("ENABLE_TIFF", "OFF")
+        .define("ENABLE_WEBP", "OFF")
+        .define("ENABLE_OPENJPEG", "OFF")
+        .define("CMAKE_INSTALL_PREFIX", &out_dir)
+        .out_dir(&format!("{}/leptonica-build-{}", out_dir, target))
+        .always_configure(true)
+        .build();
 
-    if let Some(include_path) = clang_extra_include {
-        bindings = bindings.clang_arg(format!("-I{}", include_path));
-    }
+    let lib_path = format!("{}/lib", out_dir);
+    println!("cargo:rustc-link-search=native={}", lib_path);
+    println!("cargo:rustc-link-lib=static=leptonica");
+
+    let include_path = PathBuf::from(&format!("{}/include", out_dir));
+
+    let mut bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .clang_arg(format!("-I{}", include_path.display()));
 
     bindings = bindings.blocklist_type("max_align_t");
 
@@ -95,4 +46,8 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    // Expose paths for dependent crates (becomes DEP_LEPT_* environment variables)
+    println!("cargo:include={}", include_path.display());
+    println!("cargo:lib={}", lib_path);
 }


### PR DESCRIPTION
Related to https://github.com/ccouzens/tesseract-sys/pull/30

This PR adds leptonica as a submodule, allowing the build to be fully contained. This is useful if you want to build for other systems (cross compile). For this PR to work, a similar PR on leptonica-sys is required.

Note that this also disables JPG/PNG/TIFF/... -- you are expected to handle that yourself and call `set_frame`.

If you are not interested in the change, feel free to close the PR, I need these changes and thought they may help somebody else.
